### PR TITLE
Feat: Hide transclusions + <kbd> styling

### DIFF
--- a/content/.obsidian/snippets/mmw-kbd-styling.css
+++ b/content/.obsidian/snippets/mmw-kbd-styling.css
@@ -1,20 +1,3 @@
-@use "./base.scss";
-@use "./variables.scss" as *;
-/* -- Custom SCSS Modules -- */
-@use "./custom/image-adjustments.scss";
-@use "./custom/callout-adjustments.scss";
-@use "./custom/column-callout.scss";
-@use "./custom/caption-callout.scss";
-@use "./custom/infobox-callout.scss";
-@use "./custom/maintenance-template-callout.scss";
-@use "./custom/transclusion-adjustments.scss";
-
-// put your custom CSS here!
-
-.page-title {
-    height: 175px;
-}
-
 /*---- kbd styling ----*/
 
 kbd {

--- a/content/.obsidian/snippets/mmw-transclusion-adjustments.css
+++ b/content/.obsidian/snippets/mmw-transclusion-adjustments.css
@@ -1,0 +1,20 @@
+/*Transclusions*/
+
+.internal-embed[alt~=clean].is-loaded:not(.image-embed) {
+    --embed-padding: 0;
+    border: none;
+}
+
+.internal-embed[alt~=right] {
+    float: right;
+    margin-left: 0.5em;
+  }
+  
+  .internal-embed[alt~=left] {
+    float: left;
+    margin-right: 0.5em;
+  }
+  
+  :not(.lp-embed-float) .is-live-preview .internal-embed:is([alt~=right], [alt~=left]) {
+    float: unset;
+  }

--- a/quartz/styles/custom/transclusion-adjustments.scss
+++ b/quartz/styles/custom/transclusion-adjustments.scss
@@ -1,0 +1,11 @@
+@use "../base.scss";
+@use "../variables.scss" as *;
+
+.transclude[data-embed-alias~=clean] {
+    border-left: none;
+    padding-left: 0;
+}
+
+.transclude[data-embed-alias~=clean] > .transclude-src {
+    display: none;
+}


### PR DESCRIPTION
Transclusion adjustments: transclusions' blockquote styling can be hidden by adding `|clean]]` to the alias of the embed wikilink. This makes the embedded content indistinguishable from regular content on the page.

kbd styling: wrapping a phrase in html `<kbd>` `</kbd>` tags will render the text like a keyboard key, e.g. <kbd>ctrl</kbd> + <kbd>z</kbd>