### PR TITLE
Update quartz.layout.ts

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -21,6 +21,7 @@ export const defaultContentPageLayout: PageLayout = {
     Component.ArticleTitle(),
     Component.ContentMeta(),
     Component.TagList(),
+    Component.MobileOnly(Component.TableOfContents()),
   ],
   left: [
     Component.PageTitle(),
@@ -33,7 +34,11 @@ export const defaultContentPageLayout: PageLayout = {
     })),
   ],
   right: [
-    Component.Graph(),
+    Component.MobileOnly(Component.Explorer({
+      folderClickBehavior: "link", 
+      filterFn: (node) => node.name !== "Templates",
+    })),
+    Component.DesktopOnly(Component.Graph()),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.Backlinks(),
   ],
@@ -41,7 +46,7 @@ export const defaultContentPageLayout: PageLayout = {
 
 // components for pages that display lists of pages  (e.g. tags or folders)
 export const defaultListPageLayout: PageLayout = {
-  beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta()],
+  beforeBody: [Component.Breadcrumbs(), Component.ArticleTitle(), Component.ContentMeta(), Component.MobileOnly(Component.TableOfContents())],
   left: [
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
@@ -52,5 +57,13 @@ export const defaultListPageLayout: PageLayout = {
       filterFn: (node) => node.name !== "Templates",
     })),
   ],
-  right: [],
+  right: [
+    Component.MobileOnly(Component.Explorer({
+      folderClickBehavior: "link", 
+      filterFn: (node) => node.name !== "Templates",
+    })),
+    Component.DesktopOnly(Component.Graph()),
+    Component.DesktopOnly(Component.TableOfContents()),
+    Component.Backlinks(),
+  ],
 }


### PR DESCRIPTION
- Adds MobileOnly components for Explorer and Table of Contents to display on mobile.
- Graph made DesktopOnly so its position in the layout can be replaced by the Explorer in Mobile view